### PR TITLE
@trivial

### DIFF
--- a/jquery.switchbutton.js
+++ b/jquery.switchbutton.js
@@ -222,8 +222,12 @@
 			
 		_autoResize: function() {
 			var	onLabelWidth	= this.$enabledLabel.width(),
-				offLabelWidth	= this.$disabledLabel.width(),
-				spanPadding		= this.$disabledSpan.innerWidth() - this.$disabledSpan.width()
+				offLabelWidth	= this.$disabledLabel.width();
+			//If width() return 0, then the min width of switch is maintained for default value.
+			if(offLabelWidth === 0) {
+				offLabelWidth = 32;
+			}
+			var spanPadding		= this.$disabledSpan.innerWidth() - this.$disabledSpan.width(),
 				handleMargins	= this.$handle.outerWidth() - this.$handle.innerWidth();
 			
 			var containerWidth = handleWidth = (onLabelWidth > offLabelWidth) ? onLabelWidth : offLabelWidth;


### PR DESCRIPTION
Ideally, A min width of switch must be maintained.
If the parent div is hidden when the widget is initialized, The width of switch is set to 0.
This can happen whenever width() returns incorrect value, which is well documented to be because of a number of reasons, like, display: block, width in %, input is hidden.
